### PR TITLE
restores RCzechia, which is back on CRAN after a brief hiatus

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -314,6 +314,7 @@ in support of spatial data management. Here follows a first tentative
 -   The former `geobr` package provided easy access to official spatial data sets of 
     Brazil for multiple geographies and years.
 -   `r pkg("geouy")` loads and process geographic information for Uruguay.
+-   `r pkg("RCzechia") downloads spatial boundary files of administrative regions and other spatial objects of the Czech Republic.`
 -   `r pkg("rgugik")` allows to search and retrieve data from Polish Head 
     Office of Geodesy and Cartography ("GUGiK").
 -   `r pkg("mapSpain")` downloads spatial boundary files of administrative 


### PR DESCRIPTION
RCzechia has been briefly archived on CRAN due to issues with Monterey (related to SSL encryption and HTTPS connection, not spatial data as such). These have been fixed and the package is accepted again / see https://cran.r-project.org/package=RCzechia