### PR TITLE
Move rstac to the "Interfaces to Spatial Web-Services" section

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -263,6 +263,9 @@ in support of spatial data management. Here follows a first tentative
     importing (exporting) of Earth Engine spatial objects, 
     extraction of time series, interactive map display, 
     assets management interface, and metadata display.
+-    `r pkg("rstac")` provides functions to access, search and download
+     spacetime earth observation data via [SpatioTemporal Asset Catalogs](https://stacspec.org).
+     This package supports the version 1.0.0 (and older) of the [STAC specification](https://github.com/radiantearth/stac-spec).
 
 ### Specific geospatial data sources of interest
 
@@ -310,9 +313,6 @@ in support of spatial data management. Here follows a first tentative
 -   `r pkg("mapSpain")` downloads spatial boundary files of administrative 
     regions and other spatial objects of Spain.
 -   `r pkg("mapme.biodiversity")` allows to download and process a number open datasets related to biodiversity conservation providing efficient routines and parallelization options. Datasets include among others the [Global Forest Watch](https://www.globalforestwatch.org/), [ESA/Copernicus Landcover](https://land.copernicus.eu/global/products/lc), [Worldclim ](https://www.worldclim.org/) and [NASA FIRMS](https://firms.modaps.eosdis.nasa.gov/active_fire/).
--    `r pkg("rstac")` provides functions to access, search and download
-     spacetime earth observation data via [SpatioTemporal Asset Catalog](https://stacspec.org).
-     This package supports the version 1.0.0 (and older) of the [STAC specification](https://github.com/radiantearth/stac-spec).
 
 Handling spatial data
 ---------------------


### PR DESCRIPTION
Thanks for maintaining this task view!

Looking at the list of packages in each section, it seems to me like rstac belongs much more in the "Interfaces to Spatial Web-Services" section of the task view than the "Specific sources" section. rstac provides an interface to _all_ STAC APIs, not any specific source for data.