### PR TITLE
Add terrainr to the "Specific geospatial data sources of interest" section

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -313,6 +313,10 @@ in support of spatial data management. Here follows a first tentative
 -    `r pkg("rstac")` provides functions to access, search and download
      spacetime earth observation data via [SpatioTemporal Asset Catalog](https://stacspec.org).
      This package supports the version 1.0.0 (and older) of the [STAC specification](https://github.com/radiantearth/stac-spec).
+-    `r pkg("terrainr")` provides an interface to the
+     [United States Geological Survey's National Map services](https://apps.nationalmap.gov/services/),
+     providing elevation data and orthoimagery along other basemap tiles
+     for the United States.
 
 Handling spatial data
 ---------------------


### PR DESCRIPTION
Sorry for the flurry of PRs I'm opening; Krzysztof reminded me that I should consider adding packages to task views ( https://github.com/Permian-Global-Research/rsi/issues/38 ) and I figured it made sense to treat each package as a separate PR.

This PR adds [terrainr](https://github.com/ropensci/terrainr) to the "Specific geospatial data sources of interest" section, mentioning its interface to the USGS National Map family of APIs.