### PR TITLE
Add waywiser to "Ecological analysis"

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -807,6 +807,14 @@ They include:
     single environment. It also provides several visualization
     functions, e.g. to show all labeled patches or the core area of all
     patches.
+-   `r pkg("waywiser")` helps assess models fit to spatial data, with
+    functions for calculating the spatial autocorrelation of model
+    residuals, for calculating model performance statistics, for 
+    assessing model performance across multiple spatial scales, and for
+    calculating the "area of applicability" of a model. Functions are
+    designed to be compatible with both base R and with the tidymodels
+    modeling framework, and adopt `r pkg("yardstick")` classes and
+    interfaces.
 
 The `r view("Environmetrics")` Task View contains a much more
 complete survey of relevant functions and packages.


### PR DESCRIPTION
This PR adds [waywiser](https://github.com/ropensci/waywiser) to the "Ecological analysis" section. I wasn't entirely sure if this was the correct section or if it belonged in spatial regression or geostatistics: waywiser does not fit models, but rather helps users assess models after fitting, and these models are often non-spatial machine learning approaches. The methods mostly originate in the ecology and hydrology literature, which led me to putting waywiser in this section, but I'd be happy to move it elsewhere.