### PR TITLE
Add rsi to two sections

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -263,6 +263,10 @@ in support of spatial data management. Here follows a first tentative
     importing (exporting) of Earth Engine spatial objects, 
     extraction of time series, interactive map display, 
     assets management interface, and metadata display.
+-   `r pkg("rsi")` provides functions to download, mask, and composite
+    data from [SpatioTemporal Asset Catalogs](https://stacspec.org),
+    with a particular focus on satellite imagery.
+        
 
 ### Specific geospatial data sources of interest
 
@@ -372,6 +376,10 @@ Handling spatial data
 -   The `r pkg("sits")` is an end-to-end toolkit for land use and land cover
     classification using big Earth observation data, based on machine learning
     methods applied to satellite image data cubes.
+-   The `r pkg("rsi")` package provides an interface to the
+    [Awesome Spectral Indices](https://github.com/awesome-spectral-indices/awesome-spectral-indices)
+    project, with functions for filtering the list of available indices and
+    efficiently calculating these from raster inputs.
 
 ### Spatial sampling
 


### PR DESCRIPTION
This PR adds [rsi](https://github.com/Permian-Global-Research/rsi) to two sections, "Interfaces to Spatial Web-Services" and "Data processing - specific". 

I added rsi to the "Interfaces" section based on #66 -- if rstac moves to the Interfaces section, then I think this is the best section for rsi as well (as rsi can support theoretically any STAC API). The "Data processing - specific" section is based upon rsi's `calculate_indices()` function, and its interface to the Awesome Spectral Indices project.

Thanks, and apologies again for the flurry of PRs!