### PR TITLE
Add dggridR to Spatial

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -378,9 +378,12 @@ Handling spatial data
     'multi-part' to 'single-part' geometries.
 -   `r pkg("gdistance")` and `r pkg("spaths")` provide functions to calculate distances and 
     routes on geographic grids.
-    `r pkg("geosphere")` permits computations of distance and area to be 
+-   `r pkg("geosphere")` permits computations of distance and area to be 
     carried out on spatial data in geographical coordinates.
-    `r pkg("cshapes")` package provides functions for calculating distance
+-   `r pkg("dggridR", priority = "core")` provides a discrete global grid system
+    via DGGRID. These grids are extremely useful for spatial statistics because
+    they tile the Earth with _equally_-sized hexagons, triangles, or diamonds.
+-   `r pkg("cshapes")` package provides functions for calculating distance
     matrices (see [Mapping and Measuring Country Shapes](http://journal.R-project.org/archive/2010-1/RJournal_2010-1_Weidmann+Skrede~Gleditsch.pdf)).
 -   `r pkg("magclass")` offers a data class for increased interoperability 
     working with spatial-temporal data together with corresponding functions

--- a/Spatial.md
+++ b/Spatial.md
@@ -381,7 +381,7 @@ Handling spatial data
 -   `r pkg("geosphere")` permits computations of distance and area to be 
     carried out on spatial data in geographical coordinates.
 -   `r pkg("dggridR", priority = "core")` provides a discrete global grid system
-    via DGGRID. These grids are extremely useful for spatial statistics because
+    via DGGRID. These grids are useful for spatial statistics because
     they tile the Earth with _equally_-sized hexagons, triangles, or diamonds.
 -   `r pkg("cshapes")` package provides functions for calculating distance
     matrices (see [Mapping and Measuring Country Shapes](http://journal.R-project.org/archive/2010-1/RJournal_2010-1_Weidmann+Skrede~Gleditsch.pdf)).


### PR DESCRIPTION
dggridR was previously part of the core Spatial view (71b2d231f99ba8e54974eaa08c847c2ea437dd1c), but removed after the package was archived (b2b0637c1e5bf84a51a21d1282b55b0ab8b467a7). dggridR is now back with an expanded team of maintainers (up from one previously), so we're making a PR to add the package back to the view.