### PR TITLE
Add `gdverse` package to the Spatial Task View

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -744,8 +744,13 @@ calculated rates that are comparable both in terms of levels and uncertainty.
     designed to be compatible with both base R and with the tidymodels
     modeling framework, and adopt `r pkg("yardstick")` classes and
     interfaces.
--   The `r pkg("gdverse")` package provides an integrated and extensible toolkit for analyzing spatial   stratified heterogeneity and spatial associations using the geographical detector methodology. It includes core functions for computing the q-statistic, performing spatial 
-    factor exploration, and modeling spatial interactions between variables. The package supports various geographical detector models and provides high-performance implementations for their efficient execution.
+-   The `r pkg("gdverse")` package provides 
+    an integrated and extensible toolkit for analyzing spatial stratified heterogeneity 
+    and spatial associations using the geographical detector methodology. It includes 
+    core functions for computing the q-statistic, performing spatial factor exploration, 
+    and detecting spatial interactions between variables. The package supports various 
+    geographical detector models and provides high-performance implementations for their
+    efficient execution.
 
 
 ### Spatial regression

--- a/Spatial.md
+++ b/Spatial.md
@@ -744,6 +744,8 @@ calculated rates that are comparable both in terms of levels and uncertainty.
     designed to be compatible with both base R and with the tidymodels
     modeling framework, and adopt `r pkg("yardstick")` classes and
     interfaces.
+-   The `r pkg("gdverse")` package provides an integrated and extensible toolkit for analyzing spatial   stratified heterogeneity and spatial associations using the geographical detector methodology. It includes core functions for computing the q-statistic, performing spatial 
+    factor exploration, and modeling spatial interactions between variables. The package supports various geographical detector models and provides high-performance implementations for their efficient execution.
 
 
 ### Spatial regression


### PR DESCRIPTION
This pull request adds the `gdverse` package to the Spatial Task View.

`gdverse` provides an integrated and extensible toolkit for analyzing spatial stratified heterogeneity and spatial associations using the geographical detector methodology. It includes core functions for computing the q-statistic, performing spatial factor exploration, and modeling spatial interactions between variables. The package supports various geographical detector models and provides high-performance implementations for their efficient execution.

I believe `gdverse` would be a valuable addition to the Spatial Task View, particularly in the areas of spatial association and spatial stratified heterogeneity modeling.

Thank you for considering this contribution.
