### PR TITLE
add `parzer` package

### DIFF
--- a/Spatial.md
+++ b/Spatial.md
@@ -185,7 +185,7 @@ geographic metadata in R.
     handling metadata (CF conventions) in the self-described NetCDF
     format.
 -   `r pkg("CFtime")` encapsulates the CF time coordinate and allows to deal
-    with the different CF calendars
+    with the different CF calendars.
 
 Reading and writing spatial data
 --------------------------------


### PR DESCRIPTION
I suggest adding the [parzer](https://cran.r-project.org/package=parzer) package to the list (section _Handling spatial data: Data cleaning_), which is useful for cleaning geographic coordinates. I think it will be valuable for users. The package was reviewed by rOpenSci.